### PR TITLE
thread-safety: guard registries against concurrent access, + OP-TEE and eckey-leak fixes (stacked on #330)

### DIFF
--- a/include/dogecoin/eckey.h
+++ b/include/dogecoin/eckey.h
@@ -47,6 +47,8 @@ typedef struct eckey {
 
 typedef struct dogecoin_eckey_context {
     eckey* keys;
+    dogecoin_mutex_t lock; /* guards the registry root above; no-op for the
+                              zero-initialized per-thread default context */
 } dogecoin_eckey_context;
 
 // instantiates a new eckey

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -47,6 +47,8 @@ typedef struct working_transaction {
 
 typedef struct dogecoin_transaction_context {
     working_transaction* transactions;
+    dogecoin_mutex_t lock; /* guards the registry root above; no-op for the
+                              zero-initialized per-thread default context */
 } dogecoin_transaction_context;
 
 struct dogecoin_wallet_;

--- a/src/context.c
+++ b/src/context.c
@@ -32,7 +32,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
 #include <pthread.h>
 #endif
 
@@ -53,8 +53,10 @@ static size_t dogecoin_refcount_lock_size(void)
 {
 #ifdef _WIN32
     return sizeof(CRITICAL_SECTION);
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
     return sizeof(pthread_mutex_t);
+#else
+    return sizeof(int); /* no threading runtime: lock is a no-op placeholder */
 #endif
 }
 
@@ -79,7 +81,7 @@ static void dogecoin_context_cleanup(dogecoin_context* ctx)
     if (ctx->refcount_lock) {
 #ifdef _WIN32
         DeleteCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
         pthread_mutex_destroy((pthread_mutex_t*)ctx->refcount_lock);
 #endif
         dogecoin_free(ctx->refcount_lock);
@@ -131,7 +133,7 @@ dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enab
     }
 #ifdef _WIN32
     InitializeCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
     if (pthread_mutex_init((pthread_mutex_t*)ctx->refcount_lock, NULL) != 0) {
         dogecoin_free(ctx->refcount_lock);
         ctx->refcount_lock = NULL;
@@ -186,13 +188,13 @@ void dogecoin_context_acquire(dogecoin_context* ctx)
     if (!ctx->refcount_lock) return;
 #ifdef _WIN32
     EnterCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
     pthread_mutex_lock((pthread_mutex_t*)ctx->refcount_lock);
 #endif
     ctx->refcount++;
 #ifdef _WIN32
     LeaveCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
     pthread_mutex_unlock((pthread_mutex_t*)ctx->refcount_lock);
 #endif
 }
@@ -214,14 +216,14 @@ void dogecoin_context_release(dogecoin_context* ctx)
     if (!ctx->refcount_lock) return;
 #ifdef _WIN32
     EnterCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
     pthread_mutex_lock((pthread_mutex_t*)ctx->refcount_lock);
 #endif
     if (ctx->refcount > 0) ctx->refcount--;
     if (ctx->refcount == 0) should_free = true;
 #ifdef _WIN32
     LeaveCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
-#else
+#elif defined(DOGECOIN_HAVE_THREADS)
     pthread_mutex_unlock((pthread_mutex_t*)ctx->refcount_lock);
 #endif
     if (!should_free) return;

--- a/src/eckey.c
+++ b/src/eckey.c
@@ -38,17 +38,55 @@ static dogecoin_eckey_context* default_eckey_context(void) {
     return &default_ctx;
 }
 
+/* ---- internal registry helpers; caller MUST hold ctx->lock ----
+ * Raw uthash operations with no locking, so the public _ts entry points and the
+ * composed start/free paths take the lock once and stay deadlock-free on the
+ * non-recursive mutex. */
+static void add_eckey_locked(dogecoin_eckey_context* ctx, eckey *key) {
+    eckey* key_old;
+    HASH_FIND_INT(ctx->keys, &key->idx, key_old);
+    if (key_old == NULL) {
+        HASH_ADD_INT(ctx->keys, idx, key);
+    } else {
+        HASH_REPLACE_INT(ctx->keys, idx, key, key_old);
+    }
+    dogecoin_free(key_old);
+}
+
+static eckey* find_eckey_locked(dogecoin_eckey_context* ctx, int idx) {
+    eckey* key;
+    HASH_FIND_INT(ctx->keys, &idx, key);
+    return key;
+}
+
+static void remove_eckey_locked(dogecoin_eckey_context* ctx, eckey* key) {
+    HASH_DEL(ctx->keys, key); /* delete it (keys advances to next) */
+    dogecoin_privkey_cleanse(&key->private_key);
+    dogecoin_pubkey_cleanse(&key->public_key);
+    dogecoin_key_free(key);
+}
+
 dogecoin_eckey_context* dogecoin_eckey_context_new(void) {
-    return (dogecoin_eckey_context*)dogecoin_calloc(1, sizeof(dogecoin_eckey_context));
+    dogecoin_eckey_context* ctx =
+        (dogecoin_eckey_context*)dogecoin_calloc(1, sizeof(dogecoin_eckey_context));
+    if (!ctx) return NULL;
+    if (!dogecoin_mutex_init(&ctx->lock)) {
+        dogecoin_free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void dogecoin_eckey_context_free(dogecoin_eckey_context* ctx) {
     if (!ctx) return;
     eckey* current;
     eckey* tmp;
+    dogecoin_mutex_lock(&ctx->lock);
     HASH_ITER(hh, ctx->keys, current, tmp) {
-        remove_eckey_ts(ctx, current);
+        remove_eckey_locked(ctx, current);
     }
+    dogecoin_mutex_unlock(&ctx->lock);
+    dogecoin_mutex_destroy(&ctx->lock);
     dogecoin_free(ctx);
 }
 
@@ -80,7 +118,9 @@ eckey* new_eckey_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
     if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return NULL;
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return NULL;
+    dogecoin_mutex_lock(&ctx->lock);
     key->idx = HASH_COUNT(ctx->keys) + 1;
+    dogecoin_mutex_unlock(&ctx->lock);
     return key;
 }
 
@@ -111,7 +151,9 @@ eckey* new_eckey_from_privkey_ts(dogecoin_eckey_context* ctx, char* private_key)
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
     if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return NULL;
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return NULL;
+    dogecoin_mutex_lock(&ctx->lock);
     key->idx = HASH_COUNT(ctx->keys) + 1;
+    dogecoin_mutex_unlock(&ctx->lock);
     return key;
 }
 
@@ -129,14 +171,9 @@ void add_eckey(eckey *key) {
 
 void add_eckey_ts(dogecoin_eckey_context* ctx, eckey *key) {
     if (!ctx || !key) return;
-    eckey* key_old;
-    HASH_FIND_INT(ctx->keys, &key->idx, key_old);
-    if (key_old == NULL) {
-        HASH_ADD_INT(ctx->keys, idx, key);
-    } else {
-        HASH_REPLACE_INT(ctx->keys, idx, key, key_old);
-    }
-    dogecoin_free(key_old);
+    dogecoin_mutex_lock(&ctx->lock);
+    add_eckey_locked(ctx, key);
+    dogecoin_mutex_unlock(&ctx->lock);
 }
 
 /**
@@ -154,8 +191,9 @@ eckey* find_eckey(int idx) {
 
 eckey* find_eckey_ts(dogecoin_eckey_context* ctx, int idx) {
     if (!ctx) return NULL;
-    eckey* key;
-    HASH_FIND_INT(ctx->keys, &idx, key);
+    dogecoin_mutex_lock(&ctx->lock);
+    eckey* key = find_eckey_locked(ctx, idx);
+    dogecoin_mutex_unlock(&ctx->lock);
     return key;
 }
 
@@ -173,10 +211,9 @@ void remove_eckey(eckey* key) {
 
 void remove_eckey_ts(dogecoin_eckey_context* ctx, eckey* key) {
     if (!ctx || !key) return;
-    HASH_DEL(ctx->keys, key); /* delete it (keys advances to next) */
-    dogecoin_privkey_cleanse(&key->private_key);
-    dogecoin_pubkey_cleanse(&key->public_key);
-    dogecoin_key_free(key);
+    dogecoin_mutex_lock(&ctx->lock);
+    remove_eckey_locked(ctx, key);
+    dogecoin_mutex_unlock(&ctx->lock);
 }
 
 /**
@@ -207,9 +244,16 @@ int start_key(dogecoin_bool is_testnet) {
 
 int start_key_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
     if (!ctx) return -1;
+    /* Build the key without the lock (the EC work touches no registry state),
+       then assign the index and insert under a single lock acquisition so the
+       HASH_COUNT()->HASH_ADD() allocation is atomic. new_eckey_ts assigns a
+       provisional idx; we overwrite it here under the same lock as the insert. */
     eckey* key = new_eckey_ts(ctx, is_testnet);
     if (!key) return -1;
+    dogecoin_mutex_lock(&ctx->lock);
+    key->idx = HASH_COUNT(ctx->keys) + 1;
+    add_eckey_locked(ctx, key);
     int index = key->idx;
-    add_eckey_ts(ctx, key);
+    dogecoin_mutex_unlock(&ctx->lock);
     return index;
 }

--- a/src/eckey.c
+++ b/src/eckey.c
@@ -116,8 +116,8 @@ eckey* new_eckey_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return NULL;
-    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return NULL;
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) { dogecoin_key_free(key); return NULL; }
+    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) { dogecoin_key_free(key); return NULL; }
     dogecoin_mutex_lock(&ctx->lock);
     key->idx = HASH_COUNT(ctx->keys) + 1;
     dogecoin_mutex_unlock(&ctx->lock);
@@ -139,7 +139,7 @@ eckey* new_eckey_from_privkey_ts(dogecoin_eckey_context* ctx, char* private_key)
     eckey* key = (struct eckey*)dogecoin_calloc(1, sizeof *key);
     dogecoin_privkey_init(&key->private_key);
     const dogecoin_chainparams* chain = chain_from_b58_prefix(private_key);
-    if (!dogecoin_privkey_decode_wif(private_key, chain, &key->private_key)) return NULL;
+    if (!dogecoin_privkey_decode_wif(private_key, chain, &key->private_key)) { dogecoin_key_free(key); return NULL; }
     assert(dogecoin_privkey_is_valid(&key->private_key)==1);
     dogecoin_pubkey_init(&key->public_key);
     dogecoin_pubkey_from_key(&key->private_key, &key->public_key);
@@ -149,8 +149,8 @@ eckey* new_eckey_from_privkey_ts(dogecoin_eckey_context* ctx, char* private_key)
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return NULL;
-    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return NULL;
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) { dogecoin_key_free(key); return NULL; }
+    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) { dogecoin_key_free(key); return NULL; }
     dogecoin_mutex_lock(&ctx->lock);
     key->idx = HASH_COUNT(ctx->keys) + 1;
     dogecoin_mutex_unlock(&ctx->lock);

--- a/src/eckey.c
+++ b/src/eckey.c
@@ -70,10 +70,18 @@ dogecoin_eckey_context* dogecoin_eckey_context_new(void) {
     dogecoin_eckey_context* ctx =
         (dogecoin_eckey_context*)dogecoin_calloc(1, sizeof(dogecoin_eckey_context));
     if (!ctx) return NULL;
+#if defined(_WIN32) || defined(DOGECOIN_HAVE_THREADS)
+    /* With a threading runtime, a failed mutex init is a real error. Without
+       one (e.g. OP-TEE/enclave builds), dogecoin_mutex_init() returns false by
+       design and the lock no-ops; the context is still valid, so don't treat
+       that as a construction failure. */
     if (!dogecoin_mutex_init(&ctx->lock)) {
         dogecoin_free(ctx);
         return NULL;
     }
+#else
+    (void)dogecoin_mutex_init(&ctx->lock); /* no-op; lock stays uninitialized */
+#endif
     return ctx;
 }
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -52,13 +52,60 @@ dogecoin_transaction_context* dogecoin_transaction_context_default(void) {
 }
 
 dogecoin_transaction_context* dogecoin_transaction_context_new(void) {
-    return (dogecoin_transaction_context*)dogecoin_calloc(1, sizeof(dogecoin_transaction_context));
+    dogecoin_transaction_context* ctx =
+        (dogecoin_transaction_context*)dogecoin_calloc(1, sizeof(dogecoin_transaction_context));
+    if (!ctx) return NULL;
+    if (!dogecoin_mutex_init(&ctx->lock)) {
+        dogecoin_free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void dogecoin_transaction_context_free(dogecoin_transaction_context* ctx) {
     if (!ctx) return;
-    remove_all_ts(ctx);
+    remove_all_ts(ctx); /* self-locks; safe to call without holding ctx->lock */
+    dogecoin_mutex_destroy(&ctx->lock);
     dogecoin_free(ctx);
+}
+
+/* ---- internal registry helpers; caller MUST hold ctx->lock ----
+ * These perform the raw uthash operations with no locking so the public _ts
+ * entry points (and the composed start/clear/remove_all paths) can take the
+ * lock exactly once and stay deadlock-free on the non-recursive mutex. */
+static working_transaction* new_transaction_locked(dogecoin_transaction_context* ctx) {
+    working_transaction* working_tx = (struct working_transaction*)dogecoin_calloc(1, sizeof *working_tx);
+    if (!working_tx) return NULL;
+    working_tx->transaction = dogecoin_tx_new_ts();
+    if (!working_tx->transaction) {
+        dogecoin_free(working_tx);
+        return NULL;
+    }
+    working_tx->idx = HASH_COUNT(ctx->transactions) + 1;
+    return working_tx;
+}
+
+static void add_transaction_locked(dogecoin_transaction_context* ctx, working_transaction *working_tx) {
+    working_transaction *tx;
+    HASH_FIND_INT(ctx->transactions, &working_tx->idx, tx);
+    if (tx == NULL) {
+        HASH_ADD_INT(ctx->transactions, idx, working_tx);
+    } else {
+        HASH_REPLACE_INT(ctx->transactions, idx, working_tx, tx);
+    }
+    dogecoin_free(tx);
+}
+
+static working_transaction* find_transaction_locked(dogecoin_transaction_context* ctx, int idx) {
+    working_transaction *working_tx;
+    HASH_FIND_INT(ctx->transactions, &idx, working_tx);
+    return working_tx;
+}
+
+static void remove_transaction_locked(dogecoin_transaction_context* ctx, working_transaction *working_tx) {
+    HASH_DEL(ctx->transactions, working_tx); /* delete it (transactions advances to next) */
+    dogecoin_tx_free(working_tx->transaction);
+    dogecoin_free(working_tx);
 }
 
 /**
@@ -83,16 +130,9 @@ working_transaction* new_transaction() {
 
 working_transaction* new_transaction_ts(dogecoin_transaction_context* ctx) {
     if (!ctx) return NULL;
-    working_transaction* working_tx = (struct working_transaction*)dogecoin_calloc(1, sizeof *working_tx);
-    if (!working_tx) return NULL;
-    /* Thread-safe registry entries carry a mutex-bearing transaction so the
-       _ts CLI builds operate on per-transaction-locked objects. */
-    working_tx->transaction = dogecoin_tx_new_ts();
-    if (!working_tx->transaction) {
-        dogecoin_free(working_tx);
-        return NULL;
-    }
-    working_tx->idx = HASH_COUNT(ctx->transactions) + 1;
+    dogecoin_mutex_lock(&ctx->lock);
+    working_transaction* working_tx = new_transaction_locked(ctx);
+    dogecoin_mutex_unlock(&ctx->lock);
     return working_tx;
 }
 
@@ -110,14 +150,9 @@ void add_transaction(working_transaction *working_tx) {
 
 void add_transaction_ts(dogecoin_transaction_context* ctx, working_transaction *working_tx) {
     if (!ctx || !working_tx) return;
-    working_transaction *tx;
-    HASH_FIND_INT(ctx->transactions, &working_tx->idx, tx);
-    if (tx == NULL) {
-        HASH_ADD_INT(ctx->transactions, idx, working_tx);
-    } else {
-        HASH_REPLACE_INT(ctx->transactions, idx, working_tx, tx);
-    }
-    dogecoin_free(tx);
+    dogecoin_mutex_lock(&ctx->lock);
+    add_transaction_locked(ctx, working_tx);
+    dogecoin_mutex_unlock(&ctx->lock);
 }
 
 /**
@@ -135,8 +170,9 @@ working_transaction* find_transaction(int idx) {
 
 working_transaction* find_transaction_ts(dogecoin_transaction_context* ctx, int idx) {
     if (!ctx) return NULL;
-    working_transaction *working_tx;
-    HASH_FIND_INT(ctx->transactions, &idx, working_tx);
+    dogecoin_mutex_lock(&ctx->lock);
+    working_transaction* working_tx = find_transaction_locked(ctx, idx);
+    dogecoin_mutex_unlock(&ctx->lock);
     return working_tx;
 }
 
@@ -154,9 +190,9 @@ void remove_transaction(working_transaction *working_tx) {
 
 void remove_transaction_ts(dogecoin_transaction_context* ctx, working_transaction *working_tx) {
     if (!ctx || !working_tx) return;
-    HASH_DEL(ctx->transactions, working_tx); /* delete it (transactions advances to next) */
-    dogecoin_tx_free(working_tx->transaction);
-    dogecoin_free(working_tx);
+    dogecoin_mutex_lock(&ctx->lock);
+    remove_transaction_locked(ctx, working_tx);
+    dogecoin_mutex_unlock(&ctx->lock);
 }
 
 /**
@@ -174,9 +210,11 @@ void remove_all_ts(dogecoin_transaction_context* ctx) {
     struct working_transaction *current_tx;
     struct working_transaction *tmp;
 
+    dogecoin_mutex_lock(&ctx->lock);
     HASH_ITER(hh, ctx->transactions, current_tx, tmp) {
-        remove_transaction_ts(ctx, current_tx);
+        remove_transaction_locked(ctx, current_tx);
     }
+    dogecoin_mutex_unlock(&ctx->lock);
 }
 
 /**
@@ -212,7 +250,10 @@ int get_transaction_count(void) {
 
 int get_transaction_count_ts(dogecoin_transaction_context* ctx) {
     if (!ctx) return 0;
-    return HASH_COUNT(ctx->transactions);
+    dogecoin_mutex_lock(&ctx->lock);
+    int count = HASH_COUNT(ctx->transactions);
+    dogecoin_mutex_unlock(&ctx->lock);
+    return count;
 }
 
 /* THREAD-SAFE variant - uses internal mutex */
@@ -424,10 +465,18 @@ int start_transaction() {
 
 int start_transaction_ts(dogecoin_transaction_context* ctx) {
     if (!ctx) return -1;
-    working_transaction* working_tx = new_transaction_ts(ctx);
-    if (!working_tx) return -1;
-    int index = working_tx->idx;
-    add_transaction_ts(ctx, working_tx);
+    /* Hold the lock across allocation, index assignment and insertion so the
+       HASH_COUNT()->HASH_ADD() index allocation is atomic (the original split
+       across new_transaction_ts/add_transaction_ts allowed two threads to mint
+       the same idx and clobber each other via HASH_REPLACE). */
+    dogecoin_mutex_lock(&ctx->lock);
+    working_transaction* working_tx = new_transaction_locked(ctx);
+    int index = -1;
+    if (working_tx) {
+        index = working_tx->idx;
+        add_transaction_locked(ctx, working_tx);
+    }
+    dogecoin_mutex_unlock(&ctx->lock);
     return index;
 }
 
@@ -759,10 +808,12 @@ void clear_transaction(int txindex) {
 
 void clear_transaction_ts(dogecoin_transaction_context* ctx, int txindex) {
     if (!ctx) return;
-    // find working transaction by index and pass to funciton local variable to manipulate:
-    working_transaction* tx = find_transaction_ts(ctx, txindex);
-    // remove from hashmap
-    remove_transaction_ts(ctx, tx);
+    /* find+remove under a single lock so the entry cannot be freed by another
+       thread between the lookup and the delete. */
+    dogecoin_mutex_lock(&ctx->lock);
+    working_transaction* tx = find_transaction_locked(ctx, txindex);
+    if (tx) remove_transaction_locked(ctx, tx);
+    dogecoin_mutex_unlock(&ctx->lock);
 }
 
 /**

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -55,10 +55,18 @@ dogecoin_transaction_context* dogecoin_transaction_context_new(void) {
     dogecoin_transaction_context* ctx =
         (dogecoin_transaction_context*)dogecoin_calloc(1, sizeof(dogecoin_transaction_context));
     if (!ctx) return NULL;
+#if defined(_WIN32) || defined(DOGECOIN_HAVE_THREADS)
+    /* With a threading runtime, a failed mutex init is a real error. Without
+       one (e.g. OP-TEE/enclave builds), dogecoin_mutex_init() returns false by
+       design and the lock no-ops; the context is still valid, so don't treat
+       that as a construction failure. */
     if (!dogecoin_mutex_init(&ctx->lock)) {
         dogecoin_free(ctx);
         return NULL;
     }
+#else
+    (void)dogecoin_mutex_init(&ctx->lock); /* no-op; lock stays uninitialized */
+#endif
     return ctx;
 }
 


### PR DESCRIPTION
Stacked on #330. These are three fixes for defects I hit while reviewing and building on that refactor — each verified by compile-and-run against #330's head (`41ee76ae`). None of them changes a caller contract; existing `_ts` call sites are untouched. Best reviewed/merged after #330, or folded into it if you'd prefer.

## `94bddf82` — guard transaction/eckey registries with a per-context mutex

#330's per-object locking on `dogecoin_tx` / `dogecoin_wallet` is correct, but the registry containers themselves are unsynchronized: `find_transaction_ts` / `add_transaction_ts` / `start_transaction_ts` (and the eckey equivalents) mutate `ctx->transactions` / `ctx->keys` with no lock. A heap context shared across threads — which `doc/thread_safety.md` presents as supported — races `HASH_COUNT` against `HASH_ADD` on the same root, and `start_*_ts` splits the index read from the insert across two unlocked calls, so two threads can mint the same idx and clobber each other via `HASH_REPLACE`.

I reproduced this against the repo's real `uthash.h`: 8 threads on one shared heap context gave a TSan data race (`HASH_COUNT` read vs `HASH_ADD` write) and 11/60 segfaults at `-O2`. It doesn't bite the CLI because the CLI only ever uses the thread-local default context, which is per-thread and never shared — so the bug lives entirely in the public API contract.

Adds a `dogecoin_mutex_t lock` to both context structs. Raw uthash ops move into `*_locked` helpers; public `_ts` functions become lock→helper→unlock wrappers; the composed paths (`start_*`, `clear_*`, `remove_all_*`, `*_context_free`) take the lock once. `start_*_ts` now holds the lock across `HASH_COUNT`→`HASH_ADD`, closing the index TOCTOU. The thread-local default contexts are zero-initialized, so `lock.initialized` stays false and every mutex call no-ops — per-thread registries keep their lock-free fast path.

**ABI note:** this adds a field to the public `dogecoin_transaction_context` / `dogecoin_eckey_context` structs. The change is purely additive and these contexts are only ever constructed via `*_context_new()` (never caller-sized or stack-allocated), so consumers using the documented API are unaffected — but flagging it for an explicit ack on whether that's acceptable within 0.1.x.

## `40a28916` — gate refcount lock on `DOGECOIN_HAVE_THREADS` for OP-TEE builds

`context.c` hand-rolls its refcount lock with `#ifdef _WIN32 / #else pthread`, ignoring the `DOGECOIN_HAVE_THREADS` gate the header uses to exclude `USE_OPTEE` (OP-TEE ships `<pthread.h>` but won't link `pthread_mutex_*`). Gates all six sites consistently with an `int`-sized no-op fallback. Verified by compiling `context.c` both with and without `DOGECOIN_HAVE_THREADS` — the no-threads build previously pulled in unlinkable `pthread_mutex_*`. Deliberately does **not** change the public `void* refcount_lock` field, so no ABI impact.

## `07d65dc6` — free key on `_ts` constructor error paths

`new_eckey_ts` and `new_eckey_from_privkey_ts` leak the `calloc`'d key on every error return. Frees it on all five paths: the base58-encode and p2pkh-addr failures in both functions, plus the WIF-decode failure in the privkey variant.

---

Builds clean through `tests` and `bench` on `41ee76ae`. Note: the test suite currently aborts under ASAN before reaching these paths, on the unrelated `sha2.c` `hmac_sha256_prepare` overflow (#324) — the registry-race repro above is from a standalone harness against the real `uthash.h`, not `./tests`.