### PR TITLE
doc, test: fix stale mutex note, eckey contract, and ts-context test leak

### DIFF
--- a/doc/thread_safety.md
+++ b/doc/thread_safety.md
@@ -239,9 +239,13 @@ additionally validated by the unit-test suite (`test/transaction_tests.c`,
 
 Notes:
 
-* The registry and eckey contexts hold only a hashmap and rely on per-thread
-  isolation (no internal mutex); the real locks live on `dogecoin_tx.lock`,
-  `dogecoin_wallet.lock` and the `dogecoin_ctx` refcount mutex.
+* The per-thread default registry and eckey contexts are zero-initialized;
+  their `lock.initialized == false`, so all mutex helpers no-op and they remain
+  effectively lock-free for single-threaded use. Explicitly allocated contexts
+  (`dogecoin_transaction_context_new`, `dogecoin_eckey_context_new`) carry a
+  live `dogecoin_mutex_t lock` that guards the registry root. The real
+  per-object locks live on `dogecoin_tx.lock`, `dogecoin_wallet.lock`, and the
+  `dogecoin_ctx` refcount mutex.
 * The index-based transaction API binds to the per-thread *default* transaction
   context, so the `cli_*` registry/index wrappers target that same default
   context to keep index lookups consistent.
@@ -341,11 +345,29 @@ legacy callers have **no** `release_transaction_ts` obligation. The existing
 single-threaded contract is unchanged: callers of `find_transaction` neither
 expect nor need to release.
 
+### `find_eckey_ts`: borrowed pointer, no retain
+
+Unlike `find_transaction_ts`, `find_eckey_ts` does **not** increment a
+reference count. It locks the context, locates the entry, unlocks, and returns
+a raw pointer. The returned pointer is valid only as long as no other thread
+concurrently calls `remove_eckey_ts` on the same context and key. For the
+common usage pattern — one thread owns each `dogecoin_eckey_context` — this is
+safe. Code that shares an eckey context across threads must coordinate its own
+lifetime guarantee before dereferencing the returned pointer, or restrict usage
+to within the lock by calling the internal `find_eckey_locked` directly (not a
+public API).
+
+There is **no** `release_eckey_ts` function; callers of `find_eckey_ts` have
+no release obligation.
+
 ### ABI / contract summary
 
 * `working_transaction` gained two internally-managed fields (`refcount`,
   `pending_delete`) — an additive layout change to a public struct.
 * `release_transaction_ts` is a new `LIBDOGECOIN_API` function; pairing it with
   `find_transaction_ts` is mandatory for external direct callers.
+* `find_eckey_ts` returns a borrowed pointer with no retain; no release is
+  required, but the pointer is only safe to dereference while no concurrent
+  removal can occur on the same context.
 * The legacy default-context API is unchanged in contract: borrowed pointers, no
   release required.

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -836,8 +836,13 @@ void test_transaction_ts_contexts() {
 
     u_assert_true(wtx1 != wtx2);
 
+    /* remove then release: remove_transaction_ts unlinks the entry from the
+       registry and marks pending_delete because refcount > 0; the paired
+       release_transaction_ts drops the count to zero and completes the free. */
     remove_transaction_ts(ctx1, wtx1);
+    release_transaction_ts(ctx1, wtx1);
     remove_transaction_ts(ctx2, wtx2);
+    release_transaction_ts(ctx2, wtx2);
     dogecoin_transaction_context_free(ctx1);
     dogecoin_transaction_context_free(ctx2);
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #330 addressing three issues found during re-review:

- **Stale doc note**: `thread_safety.md` "What the `_ts` CLI builds exercise" contained `(no internal mutex)` for the registry/eckey contexts — written before the registry-mutex commits. Now correctly describes the zero-init / no-op path for per-thread default contexts vs. the live `dogecoin_mutex_t lock` on explicitly allocated ones.

- **`find_eckey_ts` contract gap**: New section documents that `find_eckey_ts` returns a borrowed pointer with no retain (unlike `find_transaction_ts`), what that means for shared-context callers, and that there is no `release_eckey_ts` obligation. Extended the ABI/contract summary with the matching bullet.

- **Memory leak in `test_transaction_ts_contexts`**: `find_transaction_ts` incremented `refcount` to 1; `remove_transaction_ts` unlinked the entry from the registry and set `pending_delete=1` but did not free (refcount > 0); `dogecoin_transaction_context_free` then missed both orphaned entries (already off the hash table). Added paired `release_transaction_ts` calls to drive refcount to zero and complete the deferred free. This would have surfaced under valgrind `--leak-check=full`.

## Test plan

- [ ] `make check` / `ctest` passes with no valgrind leak reports in `test_transaction_ts_contexts`
- [ ] `doc/thread_safety.md` renders correctly (no broken references)